### PR TITLE
Fix launch reliability and slow game exit on WoW 3.3.5a

### DIFF
--- a/Sources/WoWSiliconSwift/Models/GameVersion.swift
+++ b/Sources/WoWSiliconSwift/Models/GameVersion.swift
@@ -186,6 +186,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
     var enableLibSiliconPatch: Bool
     var userDisabledLibSiliconPatch: Bool
     var useSystemProxy: Bool
+    var noProxyList: String
 
     init(
         enableVanillaTweaks: Bool = false,
@@ -199,7 +200,8 @@ struct VersionSettings: Codable, Equatable, Sendable {
         graphicsSettings: GraphicsSettings = GraphicsSettings(),
         enableLibSiliconPatch: Bool = false,
         userDisabledLibSiliconPatch: Bool = false,
-        useSystemProxy: Bool = true
+        useSystemProxy: Bool = true,
+        noProxyList: String = ""
     ) {
         self.enableVanillaTweaks = enableVanillaTweaks
         self.remapOptionAsAlt = remapOptionAsAlt
@@ -213,6 +215,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         self.enableLibSiliconPatch = enableLibSiliconPatch
         self.userDisabledLibSiliconPatch = userDisabledLibSiliconPatch
         self.useSystemProxy = useSystemProxy
+        self.noProxyList = noProxyList
     }
 
     enum CodingKeys: String, CodingKey {
@@ -222,6 +225,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         case graphicsSettings
         case enableLibSiliconPatch, userDisabledLibSiliconPatch
         case useSystemProxy
+        case noProxyList
         // Legacy keys kept for migration only
         case reduceTerrainDistance, setMultisampleTo2x, setShadowLOD0, userDisabledShadowLOD
     }
@@ -239,6 +243,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         enableLibSiliconPatch = try container.decodeIfPresent(Bool.self, forKey: .enableLibSiliconPatch) ?? false
         userDisabledLibSiliconPatch = try container.decodeIfPresent(Bool.self, forKey: .userDisabledLibSiliconPatch) ?? false
         useSystemProxy = try container.decodeIfPresent(Bool.self, forKey: .useSystemProxy) ?? true
+        noProxyList = try container.decodeIfPresent(String.self, forKey: .noProxyList) ?? ""
 
         if let gs = try container.decodeIfPresent(GraphicsSettings.self, forKey: .graphicsSettings) {
             graphicsSettings = gs
@@ -272,6 +277,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         try container.encode(enableLibSiliconPatch, forKey: .enableLibSiliconPatch)
         try container.encode(userDisabledLibSiliconPatch, forKey: .userDisabledLibSiliconPatch)
         try container.encode(useSystemProxy, forKey: .useSystemProxy)
+        try container.encode(noProxyList, forKey: .noProxyList)
     }
 
     func mergedWithDefaults(_ defaults: VersionSettings) -> VersionSettings {

--- a/Sources/WoWSiliconSwift/Models/GameVersion.swift
+++ b/Sources/WoWSiliconSwift/Models/GameVersion.swift
@@ -185,6 +185,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
     var graphicsSettings: GraphicsSettings
     var enableLibSiliconPatch: Bool
     var userDisabledLibSiliconPatch: Bool
+    var useSystemProxy: Bool
 
     init(
         enableVanillaTweaks: Bool = false,
@@ -197,7 +198,8 @@ struct VersionSettings: Codable, Equatable, Sendable {
         cursorSizeMultiplier: Int = 1,
         graphicsSettings: GraphicsSettings = GraphicsSettings(),
         enableLibSiliconPatch: Bool = false,
-        userDisabledLibSiliconPatch: Bool = false
+        userDisabledLibSiliconPatch: Bool = false,
+        useSystemProxy: Bool = true
     ) {
         self.enableVanillaTweaks = enableVanillaTweaks
         self.remapOptionAsAlt = remapOptionAsAlt
@@ -210,6 +212,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         self.graphicsSettings = graphicsSettings
         self.enableLibSiliconPatch = enableLibSiliconPatch
         self.userDisabledLibSiliconPatch = userDisabledLibSiliconPatch
+        self.useSystemProxy = useSystemProxy
     }
 
     enum CodingKeys: String, CodingKey {
@@ -218,6 +221,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         case vanillaTweaksParameters, cursorSizeMultiplier
         case graphicsSettings
         case enableLibSiliconPatch, userDisabledLibSiliconPatch
+        case useSystemProxy
         // Legacy keys kept for migration only
         case reduceTerrainDistance, setMultisampleTo2x, setShadowLOD0, userDisabledShadowLOD
     }
@@ -234,6 +238,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         cursorSizeMultiplier = try container.decodeIfPresent(Int.self, forKey: .cursorSizeMultiplier) ?? 1
         enableLibSiliconPatch = try container.decodeIfPresent(Bool.self, forKey: .enableLibSiliconPatch) ?? false
         userDisabledLibSiliconPatch = try container.decodeIfPresent(Bool.self, forKey: .userDisabledLibSiliconPatch) ?? false
+        useSystemProxy = try container.decodeIfPresent(Bool.self, forKey: .useSystemProxy) ?? true
 
         if let gs = try container.decodeIfPresent(GraphicsSettings.self, forKey: .graphicsSettings) {
             graphicsSettings = gs
@@ -266,6 +271,7 @@ struct VersionSettings: Codable, Equatable, Sendable {
         try container.encode(graphicsSettings, forKey: .graphicsSettings)
         try container.encode(enableLibSiliconPatch, forKey: .enableLibSiliconPatch)
         try container.encode(userDisabledLibSiliconPatch, forKey: .userDisabledLibSiliconPatch)
+        try container.encode(useSystemProxy, forKey: .useSystemProxy)
     }
 
     func mergedWithDefaults(_ defaults: VersionSettings) -> VersionSettings {

--- a/Sources/WoWSiliconSwift/Services/LaunchService.swift
+++ b/Sources/WoWSiliconSwift/Services/LaunchService.swift
@@ -599,6 +599,13 @@ final class LaunchService: @unchecked Sendable {
         // which would also kill unrelated Windows binaries running under Wine (e.g. VeraCrypt).
         pkill(["-9", "-f", "wine"])
 
+        // Wine's Windows system services (explorer, rpcss, services, svchost, plugplay, ...)
+        // run with argv like `C:\windows\system32\rpcss.exe` containing no "wine" text, so the
+        // pattern above misses them. Match the C:\windows prefix (double-escaped for pkill's
+        // ERE: `\\` = literal backslash). Apps installed elsewhere under Wine (e.g. VeraCrypt
+        // in Program Files) are left alone.
+        pkill(["-9", "-f", "C:\\\\windows"])
+
         // Kill wineserver and wineloader2 by path (redundant safety net)
         let resolvedCrossOverPath = crossOverPath ?? "/Applications/CrossOver.app"
         let base = resolvedCrossOverPath + "/Contents/SharedSupport/CrossOver/CrossOver-Hosted Application"

--- a/Sources/WoWSiliconSwift/Services/LaunchService.swift
+++ b/Sources/WoWSiliconSwift/Services/LaunchService.swift
@@ -177,7 +177,21 @@ final class LaunchService: @unchecked Sendable {
         // fast; without one it hits a TCP timeout (~60s), making the game appear to hang when
         // closing its window. Inject the macOS system proxy settings unless the user disabled it.
         if configuration.version.settings.useSystemProxy {
-            let systemProxy = Self.systemProxyEnvironment()
+            var systemProxy = Self.systemProxyEnvironment()
+            // Merge any user-configured NO_PROXY entries (comma-separated list,
+            // e.g. a private-server host on the LAN) with the default localhost ones.
+            let customNoProxy = configuration.version.settings.noProxyList
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if !customNoProxy.isEmpty {
+                let existing = systemProxy["NO_PROXY"] ?? ""
+                let combined = ([existing] + customNoProxy)
+                    .filter { !$0.isEmpty }
+                    .joined(separator: ",")
+                systemProxy["NO_PROXY"] = combined
+                systemProxy["no_proxy"] = combined
+            }
             for (key, value) in systemProxy where env[key] == nil {
                 env[key] = value
             }
@@ -547,9 +561,10 @@ final class LaunchService: @unchecked Sendable {
             result["ALL_PROXY"] = all
             result["all_proxy"] = all
         }
-        // Keep local/server traffic off the proxy.
-        result["NO_PROXY"] = "127.0.0.1,localhost,10.211.55.6"
-        result["no_proxy"] = "127.0.0.1,localhost,10.211.55.6"
+        // Keep local traffic off the proxy. Users can add more entries (e.g. a LAN
+        // private-server host) via the "No Proxy" option.
+        result["NO_PROXY"] = "127.0.0.1,localhost"
+        result["no_proxy"] = "127.0.0.1,localhost"
         return result
     }
 

--- a/Sources/WoWSiliconSwift/Services/LaunchService.swift
+++ b/Sources/WoWSiliconSwift/Services/LaunchService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import SystemConfiguration
 
 enum LaunchServiceError: LocalizedError {
     case alreadyRunning
@@ -55,6 +56,9 @@ final class LaunchService: @unchecked Sendable {
     private init() {}
 
     func launch(version: GameVersion, completion: @escaping @Sendable (Result<Void, LaunchServiceError>) -> Void) {
+        // Kill residual wine processes before launch to prevent display switching issues
+        Self.forceQuitWine(crossOverPath: version.crossOverPath.isEmpty ? nil : version.crossOverPath)
+
         do {
             let result = try prepareLaunchArtifacts(for: version)
 
@@ -64,10 +68,12 @@ final class LaunchService: @unchecked Sendable {
 
             if version.settings.showTerminalNormally {
                 try launchViaTerminal(configuration: result)
+                scheduleSynapticsCleanup()
                 DispatchQueue.main.async { completion(.success(())) }
                 DispatchQueue.main.async { self.processDidTerminate?() }
             } else {
                 try launchIntegrated(configuration: result, completion: completion)
+                scheduleSynapticsCleanup()
             }
         } catch let error as LaunchServiceError {
             DispatchQueue.main.async { completion(.failure(error)) }
@@ -165,37 +171,30 @@ final class LaunchService: @unchecked Sendable {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", configuration.shellCommand]
-        process.environment = ProcessInfo.processInfo.environment
-
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        stdout.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                handle.readabilityHandler = nil
-                return
-            }
-            if let text = String(data: data, encoding: .utf8), !text.isEmpty {
-                print("[GAME]", text)
+        var env = ProcessInfo.processInfo.environment
+        // The game tries to reach an external endpoint on exit (e.g. launcher.warcraftchina.com
+        // on WoW 3.3.5a private-server clients). With a proxy configured the connection fails
+        // fast; without one it hits a TCP timeout (~60s), making the game appear to hang when
+        // closing its window. Inject the macOS system proxy settings unless the user disabled it.
+        if configuration.version.settings.useSystemProxy {
+            let systemProxy = Self.systemProxyEnvironment()
+            for (key, value) in systemProxy where env[key] == nil {
+                env[key] = value
             }
         }
-        stderr.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                handle.readabilityHandler = nil
-                return
-            }
-            if let text = String(data: data, encoding: .utf8), !text.isEmpty {
-                print("[GAME:ERR]", text)
-            }
+        if env["LANG"] == nil { env["LANG"] = "zh_CN.UTF-8" }
+        if env["TERM"] == nil { env["TERM"] = "xterm-256color" }
+        if env["PATH"] == nil || !env["PATH"]!.contains("/opt/homebrew") {
+            let home = NSHomeDirectory()
+            env["PATH"] = "\(home)/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
         }
+        process.environment = env
+        // Discard game output instead of piping it: DXVK emits a large volume of logs and a
+        // Pipe can fill up (64KB) faster than it is drained, blocking the wine process.
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
         process.terminationHandler = { [weak self] _ in
-            stdout.fileHandleForReading.readabilityHandler = nil
-            stderr.fileHandleForReading.readabilityHandler = nil
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.focusTimer?.cancel()
@@ -316,6 +315,9 @@ final class LaunchService: @unchecked Sendable {
     }
 
     func launchThirdPartyLauncher(version: GameVersion, completion: @escaping @Sendable (Result<Void, LaunchServiceError>) -> Void) {
+        // Kill residual wine processes before launch to prevent display switching issues
+        Self.forceQuitWine(crossOverPath: version.crossOverPath.isEmpty ? nil : version.crossOverPath)
+
         let exePath = version.launcherExePath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !exePath.isEmpty else {
             DispatchQueue.main.async { completion(.failure(.executableMissing("No launcher configured"))) }
@@ -519,6 +521,55 @@ final class LaunchService: @unchecked Sendable {
 
     // MARK: - Force quit
 
+    /// Reads the macOS system proxy settings (System Settings → Network → Proxies)
+    /// and converts them to the standard proxy environment variables expected by Wine.
+    /// Returns an empty dict when no proxy is configured.
+    static func systemProxyEnvironment() -> [String: String] {
+        guard let proxies = SCDynamicStoreCopyProxies(nil) as? [String: Any] else { return [:] }
+
+        func proxyURL(enableKey: String, hostKey: String, portKey: String) -> String? {
+            guard let enabled = proxies[enableKey] as? Bool, enabled,
+                  let host = proxies[hostKey] as? String, !host.isEmpty,
+                  let port = proxies[portKey] as? Int, port > 0 else { return nil }
+            return "http://\(host):\(port)"
+        }
+
+        var result: [String: String] = [:]
+        if let http = proxyURL(enableKey: "HTTPEnable", hostKey: "HTTPProxy", portKey: "HTTPPort") {
+            result["HTTP_PROXY"] = http
+            result["http_proxy"] = http
+        }
+        if let https = proxyURL(enableKey: "HTTPSEnable", hostKey: "HTTPSProxy", portKey: "HTTPSPort") {
+            result["HTTPS_PROXY"] = https
+            result["https_proxy"] = https
+        }
+        if let all = result["HTTPS_PROXY"] ?? result["HTTP_PROXY"] {
+            result["ALL_PROXY"] = all
+            result["all_proxy"] = all
+        }
+        // Keep local/server traffic off the proxy.
+        result["NO_PROXY"] = "127.0.0.1,localhost,10.211.55.6"
+        result["no_proxy"] = "127.0.0.1,localhost,10.211.55.6"
+        return result
+    }
+
+    /// WoW 3.3.5a private-server clients spawn a duplicate copy of the game binary
+    /// (Synaptics.exe, byte-identical to WoW.exe) as a watchdog instance. It creates a
+    /// second game window and blocks a clean exit: closing the real game window then
+    /// waits ~60s for the watchdog to terminate. Killing it shortly after launch makes
+    /// the game exit instantly and removes the duplicate window.
+    private func scheduleSynapticsCleanup() {
+        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 8) {
+            for target in ["Synaptics.exe", "._cache_Synaptics", "start.exe"] {
+                _ = try? ProcessRunner.run(
+                    executablePath: "/usr/bin/pkill",
+                    arguments: ["-9", "-f", target],
+                    timeout: 5
+                )
+            }
+        }
+    }
+
     static func forceQuitWine(crossOverPath: String?) {
         func pkill(_ args: [String]) {
             let p = Process()
@@ -528,11 +579,12 @@ final class LaunchService: @unchecked Sendable {
             p.waitUntilExit()
         }
 
-        // Wine processes run with their Windows path as the process name (e.g. "Z:\Volumes\...\WoW.exe").
-        // pkill -f matches against the full argument string, so matching ".exe" catches them all.
-        pkill(["-9", "-f", ".exe"])
+        // Kill residual wine processes. Match "wine" in the command line (covers wineloader,
+        // wineserver, and the CrossOver wine binary) rather than the broad ".exe" pattern,
+        // which would also kill unrelated Windows binaries running under Wine (e.g. VeraCrypt).
+        pkill(["-9", "-f", "wine"])
 
-        // Kill wineserver and wineloader2 by path
+        // Kill wineserver and wineloader2 by path (redundant safety net)
         let resolvedCrossOverPath = crossOverPath ?? "/Applications/CrossOver.app"
         let base = resolvedCrossOverPath + "/Contents/SharedSupport/CrossOver/CrossOver-Hosted Application"
         for binary in ["wineserver", "wineloader", "wineloader2"] {

--- a/Sources/WoWSiliconSwift/Views/OptionsView.swift
+++ b/Sources/WoWSiliconSwift/Views/OptionsView.swift
@@ -90,6 +90,9 @@ struct OptionsView: View {
                 "Use System Proxy (fixes slow exit)",
                 binding: viewModel.boolBinding(\.useSystemProxy)
             )
+            if viewModel.currentVersion?.settings.useSystemProxy ?? false {
+                noProxyListField
+            }
             if viewModel.isVanillaTweaksSupported {
                 toggleRow(
                     "Enable vanilla-tweaks",
@@ -105,6 +108,18 @@ struct OptionsView: View {
                 UpdaterService.shared.checkForUpdates()
             }
             .buttonStyle(.bordered)
+        }
+    }
+
+    private var noProxyListField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("No Proxy (comma-separated)")
+                .font(.headline)
+            TextField("e.g. 10.211.55.6,192.168.1.1", text: viewModel.stringBinding(\.noProxyList))
+                .textFieldStyle(.roundedBorder)
+            Text("Hosts that should bypass the proxy, e.g. your private-server host on the LAN.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/WoWSiliconSwift/Views/OptionsView.swift
+++ b/Sources/WoWSiliconSwift/Views/OptionsView.swift
@@ -86,6 +86,10 @@ struct OptionsView: View {
                 "Show Terminal",
                 binding: viewModel.boolBinding(\.showTerminalNormally)
             )
+            toggleRow(
+                "Use System Proxy (fixes slow exit)",
+                binding: viewModel.boolBinding(\.useSystemProxy)
+            )
             if viewModel.isVanillaTweaksSupported {
                 toggleRow(
                     "Enable vanilla-tweaks",

--- a/Sources/WoWSiliconSwift/WoWSiliconSwiftApp.swift
+++ b/Sources/WoWSiliconSwift/WoWSiliconSwiftApp.swift
@@ -44,7 +44,11 @@ struct WoWSiliconSwiftApp: App {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        .terminateNow
+        // Clean up residual wine processes left behind by game sessions (winedevice,
+        // wineserver, Synaptics watchdog, etc.). Doing this when the app quits avoids
+        // killing the game while it is running and avoids racing with a new launch.
+        LaunchService.forceQuitWine(crossOverPath: nil)
+        return .terminateNow
     }
 }
 


### PR DESCRIPTION
Fixes #7

## Summary

This PR addresses three issues that affect WoW 3.3.5a private-server clients running via CrossOver on Apple Silicon:

### 1. Launch failure after switching displays
When WoW exits, some Wine child processes remain running. These residual processes retain the display state from the previous session, causing the game to fail to launch on a different display (garbled "3D / DirectX 9" error dialog). We now kill residual Wine processes before launching.

### 2. Duplicate game window & delayed exit
WoW 3.3.5a private-server clients spawn a byte-identical copy of the game binary (`Synaptics.exe`) as a watchdog instance. It creates a second game window and blocks a clean exit — closing the real game window waits ~60s for the watchdog to terminate. The watchdog is cleaned up shortly after launch.

### 3. ~60s hang when closing the game
These clients hit an external endpoint (`launcher.warcraftchina.com:80`) on exit. With no proxy configured, the connection hits a TCP timeout (~60s), making the game appear frozen. The macOS system proxy settings are now injected into the game environment (opt-in via a new **"Use System Proxy"** option, enabled by default), so the connection fails fast and the game exits instantly.

## Changes

- **LaunchService.swift**
  - Kill residual Wine processes before launching (both integrated and terminal launch paths)
  - `forceQuitWine` now matches `wine` instead of the broad `.exe` pattern, which could kill unrelated Windows binaries running under Wine (e.g. VeraCrypt)
  - Clean up the `Synaptics.exe` watchdog 8s after launch
  - Inject macOS system proxy settings (opt-in via `useSystemProxy`, default on)
  - Discard game output instead of piping it, avoiding Pipe backpressure blocking the Wine process on large DXVK log output
- **GameVersion.swift**: new `VersionSettings.useSystemProxy` field (Codable, backwards-compatible, defaults to `true`)
- **OptionsView.swift**: new "Use System Proxy (fixes slow exit)" toggle under General

## Testing

Verified on macOS 26.5.2 / WoWSilicon 2.5.5 / WoW 3.3.5a (zhCN private server):
- Launch succeeds after switching between internal and external displays
- Only one game window is shown and no residual Wine processes accumulate
- Closing the game exits instantly (with system proxy configured); without the option the ~60s hang reproduces