### PR TITLE
Fix Wine helper patching with x87 backends enabled

### DIFF
--- a/Sources/WoWSiliconSwift/Services/PatchService.swift
+++ b/Sources/WoWSiliconSwift/Services/PatchService.swift
@@ -91,13 +91,13 @@ enum PatchService {
         try updateDllsTxt(in: gameURL, enableLibSiliconPatch: version.settings.enableLibSiliconPatch && version.libSiliconPatchSubdirectory != nil)
 
         if version.usesRosettaPatching && version.supportsDLLLoading {
-            try patchDivxDecoder(version: version, gameURL: gameURL)
+            try patchDivxDecoder(gameURL: gameURL)
         }
 
         ensureGxResolution(in: gameURL)
     }
 
-    private static func patchDivxDecoder(version: GameVersion, gameURL: URL) throws {
+    private static func patchDivxDecoder(gameURL: URL) throws {
         guard let wineExecutable = BundledWineRuntime.wineExecutableURL() else {
             let expectedPath = BundledWineRuntime.rootURL()?
                 .appendingPathComponent("bin/wine", isDirectory: false).path ?? "Contents/Resources/Wine/bin/wine"
@@ -108,12 +108,10 @@ enum PatchService {
         env["WINEDLLOVERRIDES"] = "winemenubuilder.exe=d;mscoree=d;mshtml=d"
         env["WINEDEBUG"] = "-all"
         env["WINE_LARGE_ADDRESS_AWARE"] = "1"
-        if version.settings.x87Backend != .disabled {
-            guard let x87Runtime = BundledX87Runtime.resolve(version.settings.x87Backend) else {
-                throw PatchServiceError.resourceMissing("selected x87 runtime")
-            }
-            env[x87Runtime.wineEnvironmentKey] = x87Runtime.executableURL.path
-        }
+        // These helpers only patch files and do not execute x87 game code. The legacy
+        // Rosetta x87 backend prevents Wine from spawning the 32-bit rundll32 helper.
+        env.removeValue(forKey: "ROSETTA_X87_PATH")
+        env.removeValue(forKey: "X87_SIDECAR_PATH")
 
         let patches: [(entry: String, file: String)] = [
             ("PatchDivxDecoder", "DivxDecoder.dll"),
@@ -135,6 +133,25 @@ enum PatchService {
 
             if result.exitCode != 0 {
                 throw PatchServiceError.fileOperationFailed("Failed to run \(patch.entry): \(result.combinedOutput)")
+            }
+
+            let patchedURL = gameURL.appendingPathComponent(patch.file)
+            let backupURL = gameURL.appendingPathComponent("\(patch.file).bak")
+            guard FileManager.default.fileExists(atPath: backupURL.path) else {
+                throw PatchServiceError.fileOperationFailed(
+                    "\(patch.entry) did not create \(backupURL.lastPathComponent). The game DLL was not patched."
+                )
+            }
+            guard let patchedData = try? Data(contentsOf: patchedURL),
+                  let backupData = try? Data(contentsOf: backupURL) else {
+                throw PatchServiceError.fileOperationFailed(
+                    "Could not verify the files created by \(patch.entry)."
+                )
+            }
+            guard patchedData != backupData else {
+                throw PatchServiceError.fileOperationFailed(
+                    "\(patch.entry) left \(patch.file) unchanged. The game DLL was not patched."
+                )
             }
         }
     }

--- a/Tests/WoWSiliconSwiftTests/PatchServiceTests.swift
+++ b/Tests/WoWSiliconSwiftTests/PatchServiceTests.swift
@@ -1,0 +1,81 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import WoWSiliconSwift
+
+final class PatchServiceTests: XCTestCase {
+    func testDivxPatchingDoesNotInjectX87BackendIntoWineHelper() throws {
+        let temporaryRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PatchServiceTests-\(UUID().uuidString)", isDirectory: true)
+        let runtimeRoot = temporaryRoot.appendingPathComponent("Wine", isDirectory: true)
+        let runtimeBin = runtimeRoot.appendingPathComponent("bin", isDirectory: true)
+        let runtimeLib = runtimeRoot.appendingPathComponent("lib", isDirectory: true)
+        let gameDirectory = temporaryRoot.appendingPathComponent("Game", isDirectory: true)
+        try FileManager.default.createDirectory(at: runtimeBin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: runtimeLib, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: gameDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let wine = runtimeBin.appendingPathComponent("wine")
+        let wineScript = """
+        #!/bin/sh
+        if [ -n "${ROSETTA_X87_PATH:-}" ] || [ -n "${X87_SIDECAR_PATH:-}" ]; then
+            exit 0
+        fi
+        cp "$3/DivxDecoder.dll" "$3/DivxDecoder.dll.bak"
+        printf x >> "$3/DivxDecoder.dll"
+        """
+        try wineScript.write(to: wine, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wine.path)
+        try Data("configuration".utf8).write(to: runtimeLib.appendingPathComponent("mtld3d.conf"))
+
+        let executable = gameDirectory.appendingPathComponent("WoW.exe")
+        let decoder = gameDirectory.appendingPathComponent("DivxDecoder.dll")
+        try Data("game".utf8).write(to: executable)
+        let originalDecoder = Data("original decoder".utf8)
+        try originalDecoder.write(to: decoder)
+
+        let environmentOverrides = [
+            BundledWineRuntime.environmentOverride: runtimeRoot.path,
+            "ROSETTA_X87_PATH": "/tmp/inherited-rosetta-x87",
+            "X87_SIDECAR_PATH": "/tmp/inherited-x87-sidecar",
+        ]
+        let previousEnvironment: [String: String?] = Dictionary(
+            uniqueKeysWithValues: environmentOverrides.keys.map { key in
+                (key, ProcessInfo.processInfo.environment[key])
+            }
+        )
+        for (key, value) in environmentOverrides {
+            setenv(key, value, 1)
+        }
+        defer {
+            for (key, previousValue) in previousEnvironment {
+                if let previousValue {
+                    setenv(key, previousValue, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+
+        let version = GameVersion(
+            id: "patch-test",
+            displayName: "Patch Test",
+            wowVersion: "1.12.1",
+            gamePath: executable.path,
+            executableName: executable.lastPathComponent,
+            supportsVanillaTweaks: false,
+            supportsDLLLoading: true,
+            usesRosettaPatching: true,
+            usesDivxDecoderPatch: false,
+            settings: VersionSettings(x87Backend: .rosettaX87)
+        )
+
+        try PatchService.applyGamePatch(for: version)
+
+        let backup = gameDirectory.appendingPathComponent("DivxDecoder.dll.bak")
+        XCTAssertEqual(try Data(contentsOf: backup), originalDecoder)
+        XCTAssertNotEqual(try Data(contentsOf: decoder), originalDecoder)
+        XCTAssertTrue(PatchingStatusChecker.evaluateGamePatch(for: version).applied)
+    }
+}


### PR DESCRIPTION
## Summary

- keep x87 runtime environment variables out of Wine helpers that only patch game files
- verify that every patch operation creates its backup and actually changes the target DLL
- add a regression test covering patching while an x87 backend is selected

## Root cause

`PatchService` injected the selected x87 runtime into the Wine environment when invoking the 32-bit `rundll32` patch helpers. These helpers do not execute game x87 code, and routing them through the Rosetta x87 backend can prevent the helper from running correctly.

The patch flow previously trusted a zero exit code without checking its output files. This allowed the UI to report success even when `DivxDecoder.dll.bak` was missing and the DLL had not been modified.

## Impact

Patching no longer depends on the selected x87 translation backend. A patch is reported as successful only after the expected backup exists and the patched DLL differs from that backup.

## Validation

- `swift test` — 55 tests passed
- manually verified that the patch creates the backup and modifies the game DLL on macOS 26.6.2
