### PR TITLE
Fix legacy WoW input across macOS layout switches

### DIFF
--- a/Packaging/WineRuntime/patches/0013-winemac-stabilize-legacy-wow-input.patch
+++ b/Packaging/WineRuntime/patches/0013-winemac-stabilize-legacy-wow-input.patch
@@ -1,0 +1,71 @@
+diff --git a/dlls/winemac.drv/keyboard.c b/dlls/winemac.drv/keyboard.c
+--- a/dlls/winemac.drv/keyboard.c
++++ b/dlls/winemac.drv/keyboard.c
+@@ -442,10 +442,18 @@
+     return locale->inotneutral ? entry->id : locale->idefaultlanguage;
+ }
+ 
++static BOOL stable_ansi_hkl_enabled(void)
++{
++    const char *value = getenv("WOWSILICON_STABLE_ANSI_HKL");
++    return value && !strcmp(value, "1");
++}
++
+ static HKL get_layout_hkl(struct layout *layout)
+ {
+-    if (!layout->layout_id) return UlongToHandle(MAKELONG(layout->lang, layout->lang));
+-    return UlongToHandle(MAKELONG(layout->lang, layout->layout_id));
++    LCID locale = stable_ansi_hkl_enabled() ? LOWORD(NtUserGetKeyboardLayout(0)) : layout->lang;
++
++    if (!layout->layout_id) return UlongToHandle(MAKELONG(locale, layout->lang));
++    return UlongToHandle(MAKELONG(locale, layout->layout_id));
+ }
+ 
+ /******************************************************************
+@@ -535,6 +543,7 @@
+  */
+ HKL macdrv_get_hkl_from_source(TISInputSourceRef input)
+ {
++    LCID locale = LOWORD(NtUserGetKeyboardLayout(0));
+     struct layout *layout;
+     HKL ret = 0;
+ 
+@@ -542,7 +551,9 @@
+ 
+     update_layout_list();
+     layout = get_layout_from_source(input);
+-    if (layout) ret = get_layout_hkl(layout);
++    if (layout && stable_ansi_hkl_enabled())
++        ret = UlongToHandle(MAKELONG(locale, locale));
++    else if (layout) ret = get_layout_hkl(layout);
+ 
+     pthread_mutex_unlock(&layout_list_mutex);
+ 
+@@ -1439,6 +1450,14 @@
+ 
+             if (scan & 0x100) vkey |= 0x100;
+ 
++            if ('A' <= vkey && vkey <= 'Z')
++            {
++                if (size < 2) return 0;
++                buffer[0] = vkey;
++                buffer[1] = 0;
++                return 1;
++            }
++
+             for (i = 0; i < ARRAY_SIZE(vkey_names); i++)
+             {
+                 if (vkey_names[i].vkey == vkey)
+@@ -1598,6 +1617,12 @@
+             UInt32 deadKeyState;
+             UniCharCount len;
+             BOOL deadKey = FALSE;
++
++            if ('A' <= wCode && wCode <= 'Z')
++            {
++                ret = wCode;
++                break;
++            }
+ 
+             if ((VK_PRIOR <= wCode && wCode <= VK_HELP) ||
+                 (VK_F1 <= wCode && wCode <= VK_F24))

--- a/Sources/WoWSiliconSwift/Services/BundledWineRuntime.swift
+++ b/Sources/WoWSiliconSwift/Services/BundledWineRuntime.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum BundledWineRuntime {
     static let environmentOverride = "WOWSILICON_WINE_RUNTIME"
+    static let stableANSIKeyboardLayoutEnvironmentKey = "WOWSILICON_STABLE_ANSI_HKL"
 
     static func rootURL(
         resourceURL: URL? = Bundle.main.resourceURL,
@@ -99,10 +100,16 @@ enum BundledWineRuntime {
         return result
     }
 
-    static func shellEnvironmentAssignments(_ rawValue: String) -> String {
+    static func shellEnvironmentAssignments(
+        _ rawValue: String,
+        stabilizeANSIKeyboardLayout: Bool = false
+    ) -> String {
         var variables = BundledX87Runtime.removingWineEnvironmentKeys(
             from: parseEnvironmentVariables(rawValue)
         )
+        if stabilizeANSIKeyboardLayout, variables[stableANSIKeyboardLayoutEnvironmentKey] == nil {
+            variables[stableANSIKeyboardLayoutEnvironmentKey] = "1"
+        }
         variables.removeValue(forKey: "WINEPREFIX")
         return variables.sorted { $0.key < $1.key }
             .map { "\($0.key)=\(shellQuote($0.value))" }

--- a/Sources/WoWSiliconSwift/Services/LaunchService.swift
+++ b/Sources/WoWSiliconSwift/Services/LaunchService.swift
@@ -146,7 +146,7 @@ final class LaunchService: @unchecked Sendable {
             x87Runtime: x87Runtime,
             wowURL: wowExecutableURL,
             wineExecutablePath: wineExecutableURL.path,
-            settings: version.settings
+            version: version
         )
 
         return LaunchConfiguration(
@@ -326,7 +326,8 @@ final class LaunchService: @unchecked Sendable {
             + "(exit $_wowsilicon_status)"
     }
 
-    private func makeShellCommand(gameURL: URL, x87Runtime: BundledX87Runtime.ResolvedRuntime?, wowURL: URL, wineExecutablePath: String, settings: VersionSettings) -> String {
+    private func makeShellCommand(gameURL: URL, x87Runtime: BundledX87Runtime.ResolvedRuntime?, wowURL: URL, wineExecutablePath: String, version: GameVersion) -> String {
+        let settings = version.settings
         let game = shellQuote(gameURL.path)
         let wow = shellQuote(wowURL.path)
         let wine = shellQuote(wineExecutablePath)
@@ -343,7 +344,10 @@ final class LaunchService: @unchecked Sendable {
             value: WineRegistrySupport.winePrefixURL().path
         )
         let baseEnv = "\(winePrefix) DYLD_LIBRARY_PATH=\(dyldLibraryPath) WINE_LARGE_ADDRESS_AWARE=1 WINEDLLOVERRIDES=\"\(dllOverride)\"\(outputDeviceOverride)\(inputDeviceOverride) WOWSILICON_SPATIAL_AUDIO_MODE=\(spatialAudioMode) WOWSILICON_NORMALIZE_AUDIO=\(normalizeAudio) MTL_HUD_ENABLED=\(mtlValue) MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS=1 DXVK_ASYNC=1"
-        let custom = BundledWineRuntime.shellEnvironmentAssignments(settings.environmentVariables)
+        let custom = BundledWineRuntime.shellEnvironmentAssignments(
+            settings.environmentVariables,
+            stabilizeANSIKeyboardLayout: version.isWorldOfWarcraft
+        )
         let envPart = custom.isEmpty ? baseEnv : "\(custom) \(baseEnv)"
 
         if let x87Runtime {
@@ -540,7 +544,10 @@ final class LaunchService: @unchecked Sendable {
             value: WineRegistrySupport.winePrefixURL().path
         )
         let baseEnv = "\(winePrefix) DYLD_LIBRARY_PATH=\(dyldLibraryPath) WINE_D3D_CONFIG=renderer=vulkan WINE_LARGE_ADDRESS_AWARE=1 WINEDLLOVERRIDES=\"\(dllOverride)\"\(outputDeviceOverride)\(inputDeviceOverride) WOWSILICON_SPATIAL_AUDIO_MODE=\(spatialAudioMode) WOWSILICON_NORMALIZE_AUDIO=\(normalizeAudio) MTL_HUD_ENABLED=\(mtlValue) MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS=1 DXVK_ASYNC=1"
-        let custom = BundledWineRuntime.shellEnvironmentAssignments(version.settings.environmentVariables)
+        let custom = BundledWineRuntime.shellEnvironmentAssignments(
+            version.settings.environmentVariables,
+            stabilizeANSIKeyboardLayout: version.isWorldOfWarcraft
+        )
         let envPart = custom.isEmpty ? baseEnv : "\(custom) \(baseEnv)"
 
         let shellCommand = "cd \(launcherDir) && \(envPart) \(wine) \(exeName) --disable-gpu --in-process-gpu"

--- a/Tests/WoWSiliconSwiftTests/BundledWineRuntimeTests.swift
+++ b/Tests/WoWSiliconSwiftTests/BundledWineRuntimeTests.swift
@@ -120,6 +120,35 @@ final class BundledWineRuntimeTests: XCTestCase {
         )
     }
 
+    func testShellEnvironmentAssignmentsDefaultsStableANSIKeyboardLayoutForWoW() {
+        let variables = "WINEPREFIX=/tmp/ignored;LANG=ru_RU.UTF-8"
+        XCTAssertEqual(
+            BundledWineRuntime.shellEnvironmentAssignments(variables),
+            "LANG='ru_RU.UTF-8'"
+        )
+        XCTAssertEqual(
+            BundledWineRuntime.shellEnvironmentAssignments(
+                variables,
+                stabilizeANSIKeyboardLayout: true
+            ),
+            "LANG='ru_RU.UTF-8' WOWSILICON_STABLE_ANSI_HKL='1'"
+        )
+    }
+
+    func testShellEnvironmentAssignmentsPreservesExplicitKeyboardWorkaroundSetting() {
+        for value in ["0", "1", ""] {
+            for automatic in [false, true] {
+                XCTAssertEqual(
+                    BundledWineRuntime.shellEnvironmentAssignments(
+                        "WOWSILICON_STABLE_ANSI_HKL=\(value);WINEPREFIX=/tmp/ignored;LANG=ru_RU.UTF-8",
+                        stabilizeANSIKeyboardLayout: automatic
+                    ),
+                    "LANG='ru_RU.UTF-8' WOWSILICON_STABLE_ANSI_HKL='\(value)'"
+                )
+            }
+        }
+    }
+
     func testWineExecutableRequiresExecutableFile() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/docs/keyboard-input.md
+++ b/docs/keyboard-input.md
@@ -1,0 +1,57 @@
+# Legacy WoW keyboard input
+
+The bundled macOS Wine driver has two independent compatibility changes:
+
+- `MapVirtualKeyEx(..., MAPVK_VK_TO_CHAR)` and `GetKeyNameText` return Latin
+  uppercase A–Z for those virtual keys, as required by the Windows API.
+  Character translation still follows the active macOS layout.
+- An optional stable HKL avoids changing the ANSI charset expected by legacy
+  WoW while switching keyboard layouts.
+
+## Scope and configuration
+
+Direct game launches and third-party launcher starts for WoW profiles default
+`WOWSILICON_STABLE_ANSI_HKL` to `1` when the profile has no explicit value.
+This default covers Vanilla, TBC, and WotLK; only WotLK 3.3.5a has been manually
+verified. Generic game profiles, installers, and registry helpers do not receive
+an automatic setting.
+
+The driver enables the workaround only for the exact value `1`, without a
+language whitelist. It preserves the current HKL language when enumerating
+layouts and handling source changes; enumerated layout identifiers stay distinct.
+When disabled, HKL handling follows the official input-source-language patch.
+IME composition and non-Russian game input have not been manually verified.
+
+To disable the HKL workaround, add this line to the profile's environment
+variables:
+
+```text
+WOWSILICON_STABLE_ANSI_HKL=0
+```
+
+An explicit value overrides the launcher default. Empty values and values other
+than `1` also disable the workaround. The A–Z compatibility changes stay active.
+
+The workaround does not select an ANSI code page. For Russian input, the tested
+profile uses `LANG=ru_RU.UTF-8` and `LC_ALL=ru_RU.UTF-8`; fixing HKL alone cannot
+make a CP1252 process represent Cyrillic characters.
+
+## Validation and packaging
+
+On WotLK 3.3.5a, manual comparison found:
+
+- official r15: chat survives RU/EN switches, but WASD fails on RU, both when
+  starting with ABC and when starting with Russian;
+- A–Z changes alone: WASD works on both layouts, but Russian chat becomes garbled;
+- A–Z plus the stable HKL: both chat and WASD work in the tested RU/EN scenario;
+  login-screen layout switching also passes on the installed build.
+
+The published r15 runtime archive does not contain these local source patches.
+Before releasing this change, rebuild and package Wine, then regenerate the
+runtime artifact lock. Restoring the existing r15 archive is insufficient.
+
+`tools/wine-runtime/keyboard-smoke.c` checks A–Z mappings and consistent HKL
+language IDs through the actual Wine driver. Build it with the command in its
+header and run it with a non-English locale and the workaround enabled.
+Also check repeated layout switches on the login screen and in game: this smoke
+test cannot detect every game-specific hang.

--- a/tools/wine-runtime/keyboard-smoke.c
+++ b/tools/wine-runtime/keyboard-smoke.c
@@ -1,0 +1,36 @@
+/* Build: i686-w64-mingw32-gcc keyboard-smoke.c -o keyboard-smoke.exe -luser32
+ * Run with WOWSILICON_STABLE_ANSI_HKL=1 and a non-English LANG.
+ * Checks the real driver; switching layouts in WoW still needs a game check.
+ */
+#include <windows.h>
+#include <stdio.h>
+
+int main(void)
+{
+    HKL layouts[256], current = GetKeyboardLayout(0);
+    int count = GetKeyboardLayoutList(256, layouts), failed = 0;
+    char enabled[8];
+    BOOL stable = GetEnvironmentVariableA("WOWSILICON_STABLE_ANSI_HKL", enabled,
+                                        sizeof(enabled)) == 1 && enabled[0] == '1';
+
+    printf("current=%p layouts=%d stable=%d\n", current, count, stable);
+    if (count <= 0) return 1;
+    for (int i = 0; i < count; i++)
+    {
+        printf("layout[%d]=%p\n", i, layouts[i]);
+        if (stable && LOWORD(layouts[i]) != LOWORD(current)) failed = 1;
+    }
+    for (UINT key = 'A'; key <= 'Z'; key++)
+    {
+        WCHAR name[8];
+        UINT scan = MapVirtualKeyW(key, MAPVK_VK_TO_VSC);
+        if (MapVirtualKeyW(key, MAPVK_VK_TO_CHAR) != key ||
+            GetKeyNameTextW(scan << 16, name, 8) != 1 || name[0] != key)
+        {
+            printf("bad mapping/name: %c\n", key);
+            failed = 1;
+        }
+    }
+    puts(failed ? "FAIL" : "PASS");
+    return failed;
+}


### PR DESCRIPTION
Legacy WoW needs stable movement bindings and ANSI chat while the macOS layout changes. This fixes A–Z key mappings/names to match Windows and keeps the HKL language consistent across input-source changes and keyboard-layout enumeration.

The launcher defaults `WOWSILICON_STABLE_ANSI_HKL=1` for all WoW profiles, including third-party launcher starts, while preserving explicit values. The driver enables the workaround only for exact `1`; `0`, empty, or other values retain official HKL behavior. The workaround has no language whitelist. Generic profiles and helper processes receive no automatic setting.

The additional Wine patch preserves the official input-source-language patch. With the workaround enabled, layout enumeration retains each layout identifier while preserving the current HKL language, and source changes keep the legacy stable HKL. It makes no new Carbon input-source API calls from Wine threads.

Validation:
- 99 Swift tests passed for the launcher changes.
- All 13 patches apply to pinned Wine source; the patched driver builds and matches the applied source.
- The committed Wine smoke test fails on the inconsistent HKL enumeration and passes after the fix. A–Z/HKL checks pass for Russian, Greek, Turkish, and English process locales with the workaround enabled and disabled (8 cases).
- Manual WotLK 3.3.5a comparison: official r15 preserves chat but loses WASD on RU; A–Z alone restores WASD but garbles Russian chat; the full workaround supports both. The user also confirmed login-screen layout switching no longer hangs in the installed build.

Vanilla/TBC, IME composition, and non-Russian in-game text remain unverified. Runtime probes do not replace game checks. See `docs/keyboard-input.md` for configuration and the smoke test.

Release integration: published runtime r15 predates this change. Rebuild/repackage Wine and regenerate the artifact lock before release; the current release workflow otherwise downloads the unchanged r15 archive.

Addresses #12.
